### PR TITLE
chore(infra): setup http to https redirection

### DIFF
--- a/.ebextensions/http-to-https-redirection.config
+++ b/.ebextensions/http-to-https-redirection.config
@@ -1,4 +1,4 @@
-###################################################################################################
+####################################################################################################
 #### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ####
 #### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
@@ -9,32 +9,45 @@
 #### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
 #### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #### License for the specific language governing permissions and limitations under the License.
-###################################################################################################
+####################################################################################################
 
-###################################################################################################
-#### This configuration file modifies the default port 80 listener attached to an Application Load Balancer 
+####################################################################################################
+#### This configuration file adds a listener to the Application Load Balancer for port 443, this new listener
+#### requires the ARN of a public website certificate create residing in the certificate manager service.
+#### The configuration file also modifies the default port 80 listener attached to an Application Load Balancer 
 #### to automatically redirect incoming connections on HTTP to HTTPS.
 #### This will not work with an environment using the load balancer type Classic or Network.
-#### A prerequisite is that the 443 listener has already been created. 
-#### Please use the below link for more information about creating an Application Load Balancer on 
-#### the Elastic Beanstalk console.
-#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-alb.html#environments-cfg-alb-console
-###################################################################################################
+#### Do not use this configuration file if a listener has already been created for port 443 from the console.
+####################################################################################################
 
 Resources:
- AWSEBV2LoadBalancerListener:
-  Type: AWS::ElasticLoadBalancingV2::Listener
-  Properties:
-    LoadBalancerArn:
-      Ref: AWSEBV2LoadBalancer
-    Port: 80
-    Protocol: HTTP
-    DefaultActions:
-      - Type: redirect
-        RedirectConfig:
-          Host: "#{host}"
-          Path: "/#{path}"
-          Port: "443"
-          Protocol: "HTTPS"
-          Query: "#{query}"
-          StatusCode: "HTTP_301"
+  AWSEBV2LoadBalancerListener:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: '443'
+            Host: '#{host}'
+            Path: '/#{path}'
+            Query: '#{query}'
+            StatusCode: HTTP_301
+      LoadBalancerArn:
+        Ref: AWSEBV2LoadBalancer
+      Port: 80
+      Protocol: HTTP
+  AWSEBV2LoadBalancerListenerHTTPS:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      Certificates:
+        - CertificateArn: Replace with Certificate ARN
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn:
+            Ref: AWSEBV2LoadBalancerTargetGroup
+      LoadBalancerArn:
+        Ref: AWSEBV2LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+


### PR DESCRIPTION
This pull request aims to introduce the necessary Elastic Beanstalk configuration to have all traffic be redirected to the HTTPS load balancer